### PR TITLE
Stay on the main screen if not connected

### DIFF
--- a/app/src/main/java/com/tolkiana/spotifyplayer/MainActivity.kt
+++ b/app/src/main/java/com/tolkiana/spotifyplayer/MainActivity.kt
@@ -13,7 +13,9 @@ class MainActivity : AppCompatActivity() {
 
         connectButton.setOnClickListener {
             SpotifyService.connect(this) {
-                showPlayer()
+                if(it) {
+                    showPlayer()
+                }
             }
         }
     }


### PR DESCRIPTION
My opinion is that is a good idea to leave the user on the welcome screen if the connection to Spotify fails.